### PR TITLE
Refactor and add sandbox options

### DIFF
--- a/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerClient.lua
+++ b/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerClient.lua
@@ -4,27 +4,37 @@
 --              respondServerItems
 --              respondClientItems
 
-local function predicateWeapon(item)
-	return item:IsWeapon()
-	-- return item:IsWeapon() and item:getActualWeight() >= 1
+SearchPlayer = SearchPlayer or {}
+
+function SearchPlayer.predicateWeapon(item)
+    return item:IsWeapon()
+    -- return item:IsWeapon() and item:getActualWeight() >= 1
+end
+
+function SearchPlayer.reportBeingSearched(player, otherPlayer)
+    player:Say("Being searched by " .. otherPlayer:getDisplayName())
 end
 
 local function OnServerCommand(module, command, args)
-    if module == "SearchPlayer" then
-        if command == "requestClientItems" then
-            local player = getPlayer();
-            local otherPlayer = getPlayerByOnlineID(args[1])
-            local playerInv = player:getInventory();
-            local weapons = playerInv:getAllEval(predicateWeapon);
-            player:Say("Being searched by " .. otherPlayer:getDisplayName())
-            print("Found " .. weapons:size() .. " weapons");
-            if weapons and weapons:size() > 0 then
-                for i=1,weapons:size() do
-                    local item = weapons:get(i-1)
-                    print(item:getName())
-                    tradingUISendAddItem(player, otherPlayer, item);
-                end
-            end
+    if module ~= "SearchPlayer" then
+        return
+    end
+
+    if command == "requestClientItems" then
+        local player = getPlayer();
+        local otherPlayer = getPlayerByOnlineID(args[1])
+        if not otherPlayer then
+            return
+        end
+
+        local playerInv = player:getInventory();
+        local weapons = playerInv:getAllEval(SearchPlayer.predicateWeapon);
+        SearchPlayer.reportBeingSearched(player, otherPlayer)
+        print("Found " .. weapons:size() .. " weapons");
+        for i=0,weapons:size()-1 do
+            local item = weapons:get(i)
+            print(item:getName())
+            tradingUISendAddItem(player, otherPlayer, item);
         end
     end
 end

--- a/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerClient.lua
+++ b/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerClient.lua
@@ -6,8 +6,23 @@
 
 SearchPlayer = SearchPlayer or {}
 
+function SearchPlayer.isOtherContraband(item)
+    local vars = SandboxVars.SearchPlayer
+    local otherContraband = vars and vars.OtherContrabandItems or ''
+
+    local typeList = string.split(otherContraband, ';')
+    local fullType = item:getFullType()
+    for i = 1, #typeList do
+        if fullType == string.trim(typeList[i]) then
+            return true
+        end
+    end
+
+    return false
+end
+
 function SearchPlayer.predicateWeapon(item)
-    return item:IsWeapon()
+    return item:IsWeapon() or SearchPlayer.isOtherContraband(item)
     -- return item:IsWeapon() and item:getActualWeight() >= 1
 end
 

--- a/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerClient.lua
+++ b/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerClient.lua
@@ -21,13 +21,19 @@ function SearchPlayer.isOtherContraband(item)
     return false
 end
 
-function SearchPlayer.predicateWeapon(item)
+function SearchPlayer.hasOtherContrabandConfigured()
+    local vars = SandboxVars.SearchPlayer
+    local value = vars and vars.OtherContrabandItems
+    return value and value ~= ''
+end
+
+function SearchPlayer.predicateContraband(item)
     return item:IsWeapon() or SearchPlayer.isOtherContraband(item)
     -- return item:IsWeapon() and item:getActualWeight() >= 1
 end
 
 function SearchPlayer.reportBeingSearched(player, otherPlayer)
-    player:Say("Being searched by " .. otherPlayer:getDisplayName())
+    player:Say(getText("UI_SearchedBy", otherPlayer:getDisplayName()))
 end
 
 local function OnServerCommand(module, command, args)
@@ -43,7 +49,7 @@ local function OnServerCommand(module, command, args)
         end
 
         local playerInv = player:getInventory();
-        local weapons = playerInv:getAllEval(SearchPlayer.predicateWeapon);
+        local weapons = playerInv:getAllEval(SearchPlayer.predicateContraband);
         SearchPlayer.reportBeingSearched(player, otherPlayer)
         print("Found " .. weapons:size() .. " weapons");
         for i=0,weapons:size()-1 do

--- a/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerContextOption.lua
+++ b/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerContextOption.lua
@@ -26,7 +26,7 @@ function SearchPlayer.createContextOption(player, context, worldObjects)
         local movingObjects = square:getMovingObjects()
         for i = 0, movingObjects:size() - 1 do
             local o = movingObjects:get(i)
-            if instanceof(o, "IsoPlayer") then
+            if instanceof(o, "IsoPlayer") and o ~= playerObj then
                 otherPlayer = o;
                 break
             end
@@ -53,7 +53,7 @@ function SearchPlayer.createContextOption(player, context, worldObjects)
         end
     end
 
-    if otherPlayer and otherPlayer ~= playerObj and not otherPlayer:isAsleep() and isClient() then
+    if otherPlayer and not otherPlayer:isAsleep() and isClient() then
         local text = SearchPlayer.getContextOptionText(otherPlayer)
         local option = context:addOption(text, worldObjects, SearchPlayer.onContextSelected, playerObj, otherPlayer)
         if math.abs(playerObj:getX() - otherPlayer:getX()) > 2 or math.abs(playerObj:getY() - otherPlayer:getY()) > 2 then

--- a/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerContextOption.lua
+++ b/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerContextOption.lua
@@ -1,4 +1,11 @@
-function onSearchPlayerContextSelected(worldobjects, playerObj, otherPlayer)
+SearchPlayer = SearchPlayer or {}
+
+
+function SearchPlayer.getContextOptionText(otherPlayer)
+    return getText("UI_SearchStub", otherPlayer:getDisplayName())
+end
+
+function SearchPlayer.onContextSelected(worldobjects, playerObj, otherPlayer)
     print(playerObj:getDisplayName() .. " is searching " .. otherPlayer:getDisplayName());
     print(playerObj:getDisplayName() .. " : " .. playerObj:getOnlineID())
     print(otherPlayer:getDisplayName() .. " : " .. otherPlayer:getOnlineID())
@@ -7,17 +14,16 @@ function onSearchPlayerContextSelected(worldobjects, playerObj, otherPlayer)
     end
 end
 
-function searchPlayerContextOption(player, context, worldObjects)
+function SearchPlayer.createContextOption(player, context, worldObjects)
     local playerObj = getSpecificPlayer(player);
-    local playerInv = playerObj:getInventory();
-    
-    local otherPlayer = nil;
+
+    local otherPlayer;
 
     local square;
 
-    for i, v in ipairs(worldObjects) do
-        local movingObjects = v:getSquare():getMovingObjects()
+    for _, v in ipairs(worldObjects) do
         square = v:getSquare();
+        local movingObjects = square:getMovingObjects()
         for i = 0, movingObjects:size() - 1 do
             local o = movingObjects:get(i)
             if instanceof(o, "IsoPlayer") then
@@ -27,13 +33,17 @@ function searchPlayerContextOption(player, context, worldObjects)
         end
     end
 
-    if otherplayer == nil then
-        for x=square:getX()-1,square:getX()+1 do
-            for y=square:getY()-1,square:getY()+1 do
-                local sq = getCell():getGridSquare(x,y,square:getZ());
+    if square and not otherPlayer then
+        local squareX = square:getX()
+        local squareY = square:getY()
+        local squareZ = square:getZ()
+        for x=squareX-1,squareX+1 do
+            for y=squareY-1,squareY+1 do
+                local sq = getCell():getGridSquare(x,y,squareZ);
                 if sq then
-                    for i=0,sq:getMovingObjects():size()-1 do
-                        local o = sq:getMovingObjects():get(i)
+                    local movingObjects = sq:getMovingObjects()
+                    for i=0,movingObjects:size()-1 do
+                        local o = movingObjects:get(i)
                         if instanceof(o, "IsoPlayer") and (o ~= playerObj) then
                             otherPlayer = o
                         end
@@ -44,8 +54,8 @@ function searchPlayerContextOption(player, context, worldObjects)
     end
 
     if otherPlayer and otherPlayer ~= playerObj and not otherPlayer:isAsleep() and isClient() then
-        local text = getText("UI_SearchStub", otherPlayer:getDisplayName());
-        local option = context:addOption(text, worldobjects, onSearchPlayerContextSelected, playerObj, otherPlayer)
+        local text = SearchPlayer.getContextOptionText(otherPlayer)
+        local option = context:addOption(text, worldObjects, SearchPlayer.onContextSelected, playerObj, otherPlayer)
         if math.abs(playerObj:getX() - otherPlayer:getX()) > 2 or math.abs(playerObj:getY() - otherPlayer:getY()) > 2 then
             local tooltip = ISWorldObjectContextMenu.addToolTip();
             option.notAvailable = true;
@@ -55,4 +65,5 @@ function searchPlayerContextOption(player, context, worldObjects)
     end
 end
 
-Events.OnFillWorldObjectContextMenu.Add(searchPlayerContextOption)
+
+Events.OnFillWorldObjectContextMenu.Add(SearchPlayer.createContextOption)

--- a/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerUI.lua
+++ b/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/client/SearchPlayerUI.lua
@@ -1,3 +1,4 @@
+SearchPlayer = SearchPlayer or {}
 SearchPlayerUI = ISPanel:derive("SearchPlayerUI");
 
 function SearchPlayerUI:initialise()
@@ -117,13 +118,16 @@ end
 
 function SearchPlayerUI:prerender()
     local z = 15;
-    local x = 10;
+    local suffix = self.wasContrabandSearch and "Contraband" or "Weapons"
+    local title = getText("UI_SearchingTitle" .. suffix)
+
     self:drawRect(0, 0, self.width, self.height, self.backgroundColor.a, self.backgroundColor.r, self.backgroundColor.g, self.backgroundColor.b);
-    self:drawText(getText("UI_Searching"), self.width/2 - (getTextManager():MeasureStringX(UIFont.Medium, getText("UI_Searching")) / 2), z, 1,1,1,1, UIFont.Medium);
+    self:drawText(title, self.width/2 - (getTextManager():MeasureStringX(UIFont.Medium, title) / 2), z, 1,1,1,1, UIFont.Medium);
+
     if self.foundAnything then
-        self:drawText(getText("UI_SearchingItemsFound"), self.foundItems.x, self.foundItems.y - 32, 1,1,1,1, UIFont.Small);
+        self:drawText(getText("UI_SearchingFound" .. suffix), self.foundItems.x, self.foundItems.y - 32, 1,1,1,1, UIFont.Small);
     else
-        self:drawText(getText("UI_SearchingNoItems"), self.foundItems.x, self.foundItems.y, 1,1,1,1, UIFont.Small);
+        self:drawText(getText("UI_SearchingNo" .. suffix), self.foundItems.x, self.foundItems.y, 1,1,1,1, UIFont.Small);
     end
     -- self:drawText(getText("IGUI_TradingUI_HisOffer", self.otherPlayer:getDisplayName()), self.hisOfferDatas.x, self.hisOfferDatas.y - 32, 1,1,1,1, UIFont.Small);
 end
@@ -153,6 +157,7 @@ function SearchPlayerUI:new(x, y, width, height, player, otherPlayer)
     o.otherPlayer = otherPlayer;
     o.moveWithMouse = true;
     o.foundAnything = false;
+    o.wasContrabandSearch = SearchPlayer.hasOtherContrabandConfigured()
     SearchPlayerUI.instance = o;
     return o;
 end

--- a/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/shared/Translate/EN/Sandbox_EN.txt
+++ b/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/shared/Translate/EN/Sandbox_EN.txt
@@ -1,0 +1,6 @@
+Sandbox_EN = {
+    Sandbox_SearchPlayer = "Search Players For Weapons",
+
+    Sandbox_SearchPlayer_OtherContrabandItems = "Other Contraband Items",
+    Sandbox_SearchPlayer_OtherContrabandItems_tooltip = "A list of other item types to include when searching players, separated by semicolons (e.g. Base.Battery;Base.Bleach).",
+}

--- a/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/shared/Translate/EN/UI_EN.txt
+++ b/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/lua/shared/Translate/EN/UI_EN.txt
@@ -1,8 +1,12 @@
 UI_EN = {
-    UI_Searching = "Weapons search",
+    UI_SearchingTitleWeapons = "Weapons search",
+    UI_SearchingTitleContraband = "Contraband search",
     UI_SearchingUIHelp = "<CENTRE> <SIZE:medium> Use this UI to search other players for weapons in their primary inventory. <LINE> <LINE> <SIZE:small> <LEFT> Items contained in their backpack or other worn/held storage containers will not be shown. <LINE> <LINE> This won't remove the items from them, it just shows you if they're holding something that could be dangerous.",
-    UI_SearchingItemsFound = "Found weapons",
-    UI_SearchingNoItems = "No weapons",
+    UI_SearchingFoundWeapons = "Found weapons",
+    UI_SearchingFoundContraband = "Found contraband",
+    UI_SearchingNoWeapons = "No weapons",
+    UI_SearchingNoContraband = "No contraband",
     UI_SearchingGetCloser = "You must get closer to search them",
     UI_SearchStub = "Search %1",
+    UI_SearchedBy = "Being searched by %1",
 }

--- a/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/sandbox-options.txt
+++ b/SearchPlayersForWeapons/Contents/mods/SearchPlayersForWeapons/media/sandbox-options.txt
@@ -1,0 +1,9 @@
+VERSION = 1,
+
+option SearchPlayer.OtherContrabandItems
+{
+    type = string,
+    default =,
+    page = SearchPlayer,
+    translation = SearchPlayer_OtherContrabandItems,
+}


### PR DESCRIPTION
- A refactor of the code to declare a single global, `SearchPlayer`, and define functions within it that other mods can override.
- A fix for a bug that prevented finding the other player for the context when the current player was found first.
- A sandbox option for including other "contraband" item types that will be included when searching for players.
   - This addresses #1.

It may be ideal to make other changes to support the "other contraband" option. In particular, the menu currently always reads "Weapons search", "No weapons", and "Weapons found"—if this option is used, the items may not always be weapons. If you'd prefer to address this in the future more thoroughly, I can revert that change. Otherwise, if you have thoughts on how that should be addressed (or whether it's worth addressing at all), I could make those changes here.